### PR TITLE
add keyv@4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "p-any": "^1.1.0"
   },
   "peerDependencies": {
-    "keyv": "^1 || ^2 || ^3"
+    "keyv": "^1 || ^2 || ^3 || ^4"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
Hello,

I was using `memoized-keyv` with `keyv@4` for long time, so I'm sure it's fully compatible.

This change is necessary to make `memoized-keyv` compatible with Node 15.x since right now it's throwing an error:

```bash
npm install --production
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: microlink-api@2.22.22
npm ERR! Found: keyv@4.0.3
npm ERR! node_modules/keyv
npm ERR!   keyv@"~4.0.3" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer keyv@"^1 || ^2 || ^3" from memoized-keyv@1.1.2
npm ERR! node_modules/memoized-keyv
npm ERR!   memoized-keyv@"~1.1.2" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/kikobeats/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/kikobeats/.npm/_logs/2021-01-05T11_24_32_537Z-debug.log
```